### PR TITLE
Fixed comparison not working for non-null terminated strings

### DIFF
--- a/library/hwlib-string.hpp
+++ b/library/hwlib-string.hpp
@@ -7,7 +7,7 @@
 // This code is partially based on a research project by Martin Broers.
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 // ==========================================================================
@@ -24,7 +24,7 @@
 
 namespace hwlib {
 
-// forward declaration of the class template   
+// forward declaration of the class template
 template< size_t maximum_length > class string;
 
 // return the end iterator from an asciz string
@@ -35,17 +35,17 @@ constexpr const char * asciz_beyond( const char * p ){
    return p;
 }
 
-  
+
 //============================================================================
 //
 // string< 0 >
-//  
+//
 //============================================================================
 
 /// \brief
 /// abstract fixed-maximum-length string
-/// \details  
-/// This is a string class template with a fixed maximum length. 
+/// \details
+/// This is a string class template with a fixed maximum length.
 /// The maximum length is the template parameter.
 /// All such strings inherit from string< 0 >.
 ///
@@ -62,7 +62,7 @@ constexpr const char * asciz_beyond( const char * p ){
 /// code size, not maximum speed.
 ///
 /// For assignment, appending, and comparison the following types are
-/// supported for the other side: 
+/// supported for the other side:
 ///    - char
 ///    - asciz const char pointer (C-style string)
 ///    - types that provide begin() and end() iterators (which includes
@@ -73,21 +73,21 @@ constexpr const char * asciz_beyond( const char * p ){
 ///
 ///     std::string s = "[" + text + "]";
 ///
-/// you will have to write 
+/// you will have to write
 ///
-///     hwlib::string< 20 > s; 
+///     hwlib::string< 20 > s;
 ///     s.clear() << "[" << text << "]";
-/// 
+///
 /// (The .clear() is not strictly needed because the default constructor
 /// creates an empty string, but it improves readability).
 //
 template<>
 class string< 0 > {
-private:   
-   
+private:
+
    // maximum length (maximum number of valid characters) of the string
    const size_t allocated_length;
-   
+
    // current length (number of valid characters) of the string
    size_t current_length;
 
@@ -95,22 +95,22 @@ private:
    char * const content;
 
    // dummy char used for out-of-bounds accesses
-   static char dummy; 
-   
+   static char dummy;
+
    // only string< N > is allowed to construct a string< 0 >
    template< size_t > friend class string;
-   
+
    // return a pointer into the context, clipped to the valid range
    const char * sanitize( size_t n ){
       return ( n <= current_length )
          ? content + n
          : content + current_length;
    }
-   
+
    // object constructor, called by string< N >'s constructors
-   template< typename T > 
+   template< typename T >
    constexpr string( size_t allocated_length, char * content, const T & x ):
-      allocated_length{ allocated_length }, 
+      allocated_length{ allocated_length },
       current_length{ 0 },
       content{ content }
    {
@@ -119,46 +119,46 @@ private:
             content[ current_length++ ] = c;
          }
       }
-   }     
-   
+   }
+
    // range constructor, called by range()
    // not used directly, because the result must be a const
    constexpr string( char * start, char * beyond ):
       allocated_length( beyond - start ),
       current_length( beyond - start ),
       content( start )
-   {}      
-   
+   {}
+
    //=========================================================================
    //
    // iterator(s) for char sources
    //
    //=========================================================================
-   
+
    class iterate {
-       
+
    public:
-    
+
       // iterate over a single char
       constexpr iterate( char ch ) :
-         c( ch ), start( &c ), beyond( &this->c + 1) 
+         c( ch ), start( &c ), beyond( &this->c + 1)
       {}
-       
-      // iterate over an asciz string       
+
+      // iterate over an asciz string
       constexpr iterate( const char *p ) :
          c( 0 ), start( p ), beyond( asciz_beyond( p )) {
       }
- 
-      // iterate over anything that has begin() and end() 
+
+      // iterate over anything that has begin() and end()
       template< typename T >
       constexpr iterate( const T & s ) :
          c( 0 ), start( s.begin() ), beyond( s.end() )
-      {}   
+      {}
 
       constexpr const char * begin() const {
          return start;
       }
-        
+
       constexpr const char * end() const {
          return beyond;
       }
@@ -168,7 +168,7 @@ private:
       const char * const start;
       const char * const beyond;
    };
-   
+
 public:
 
    //=========================================================================
@@ -176,89 +176,89 @@ public:
    // miscellaneous
    //
    //=========================================================================
-   
+
    /// special value for beyond-end or not-found
    static const size_t nsize = 1;
-   
-   /// \brief   
+
+   /// \brief
    /// pointer to the 0-terminated content
    /// \details
    /// This function 0-terminates the string and returns a pointer
-   /// to it. 
+   /// to it.
    ///
-   /// When the string is at its maximum size, its last character will be 
-   /// removed (making the string 1 shorter) 
+   /// When the string is at its maximum size, its last character will be
+   /// removed (making the string 1 shorter)
    /// to make room for the terminating 0-character.
    ///
-   /// When the string contains a '\0' character, this is not handled 
+   /// When the string contains a '\0' character, this is not handled
    /// specially, and the asciz string will appear to end at that character.
    char * c_str(){
       if( current_length == allocated_length ){
-         --current_length;         
+         --current_length;
       }
-      content[ current_length ] = '\0';      
+      content[ current_length ] = '\0';
       return content;
    }
 
-   /// \brief   
+   /// \brief
    /// the maximum number of characters that can be stored
    constexpr size_t max_size() const {
       return allocated_length;
-   }   
-    
-   /// \brief   
+   }
+
+   /// \brief
    /// the number of characters that are currently stored
    constexpr size_t length() const {
       return current_length;
-   }     
-   
-   /// \brief   
+   }
+
+   /// \brief
    /// check index for validity
    /// \details
    /// Return whether n is a valid index.
    constexpr bool valid_index( const size_t n ) const {
       return( n < allocated_length );
    }
-   
-   /// \brief   
+
+   /// \brief
    /// output to any target that supports operator<< for a char *
    template< typename T >
    friend T & operator<< ( T & lhs, const string< 0 > & rhs ){
       for( char c : rhs ){
          lhs << c;
-      }   
+      }
       return lhs;
-   }     
-   
-   
+   }
+
+
    //=========================================================================
    //
    // append
    //
    //=========================================================================
 
-   /// \brief   
-   /// append the char if possible, otherwise ignore it  
+   /// \brief
+   /// append the char if possible, otherwise ignore it
    string & append( char c ){
       if( current_length < allocated_length ){
          content[ current_length++ ] = c;
-      }   
+      }
       return *this;
    }
-   
-   /// \brief   
-   /// append a char if possible, otherwise ignore it 
+
+   /// \brief
+   /// append a char if possible, otherwise ignore it
    string & operator+=( char c ){
       return append( c );
    }
-   
-   /// \brief   
-   /// append a char if possible, otherwise ignore it    
+
+   /// \brief
+   /// append a char if possible, otherwise ignore it
    string & operator<<( char c ){
       return append( c );
    }
-   
-   /// \brief   
+
+   /// \brief
    /// append something (as far as possible, ignore the excess)
    template< typename T >
    string & operator+=( const T & rhs ){
@@ -267,67 +267,67 @@ public:
       }
       return *this;
    }
-   
-   /// \brief   
-   /// append something (as far as possible, ignore the excess)   
+
+   /// \brief
+   /// append something (as far as possible, ignore the excess)
    template< typename T >
    string & operator<<( const T & rhs ){
       return operator+=( rhs );
    }
-   
-   
+
+
    //=========================================================================
    //
    // assign
    //
-   //=========================================================================   
-   
-   /// \brief   
+   //=========================================================================
+
+   /// \brief
    /// set to ""
    string & clear(){
       current_length = 0;
       return *this;
-   } 
-   
-   /// \brief   
+   }
+
+   /// \brief
    /// assign something
    template< typename T >
    string & operator=( const T & rhs ){
       return clear() += rhs;
-   }   
-   
-   
+   }
+
+
    //=========================================================================
    //
    // iterate
    //
-   //=========================================================================       
-   
-   /// \brief   
+   //=========================================================================
+
+   /// \brief
    /// start iterator
    char * begin() {
       return content;
    }
 
-   /// \brief   
+   /// \brief
    /// end iterator
    char * end() {
       return content + current_length;
-   }   
-   
-   /// \brief   
+   }
+
+   /// \brief
    /// start const iterator
    const char * begin() const {
       return content;
    }
 
-   /// \brief   
+   /// \brief
    /// end const iterator
    const char * end() const {
       return content + current_length;
-   }   
-   
-   
+   }
+
+
    //=========================================================================
    //
    // range
@@ -335,44 +335,44 @@ public:
    //=========================================================================
 
    /// \brief
-   /// non-owning string (sub)range from two iterators 
+   /// non-owning string (sub)range from two iterators
    /// \details
-   /// This function returns a const string object that appears to contains 
-   /// the characters range pointed to by the start parameter up to 
+   /// This function returns a const string object that appears to contains
+   /// the characters range pointed to by the start parameter up to
    /// (but excluding) the character pointed to by the end parameter.
-   /// 
+   ///
    /// The object is a non-owning range: it doesn't make a copy.
    /// Hence any change to the characters will be reflected in the range.
-   static constexpr const string< 0 > range( 
-      const char * start, 
-      const char * beyond 
+   static constexpr const string< 0 > range(
+      const char * start,
+      const char * beyond
    ){
       // Casting the const away is OK because the returned range object is
       // returned as const, so the stored char pointers are const again.
       // Blame C++ for not having a const constructor :(
-      return string( 
-         const_cast< char * >( start ), 
+      return string(
+         const_cast< char * >( start ),
          const_cast< char * >( beyond )
       );
-   }      
-   
+   }
+
    /// \brief
    /// non-owning string (sub)range from an asciz string
    /// \details
-   /// This function returns a const string object that appears to contains 
+   /// This function returns a const string object that appears to contains
    /// the characters in the asciz string pointed to by the start parameter.
-   /// 
+   ///
    /// The object is a non-owning range: it doesn't make a copy.
    /// Hence any change to the characters will be reflected in the range.
    static constexpr const string< 0 > range(
       const char * start
    ){
       // see above
-      return string( 
-         const_cast< char * >( start ), 
+      return string(
+         const_cast< char * >( start ),
          const_cast< char * >( asciz_beyond( start ) )
       );
-   }  
+   }
 
 
    //=========================================================================
@@ -380,53 +380,53 @@ public:
    // erase & replace
    //
    //=========================================================================
-   
-   /// \brief     
+
+   /// \brief
    /// remove a substring
    /// \details
    ///
-   
-   
-   
+
+
+
    // replace_inplace
    // inplace_replace
-   // inplace_erase   
-   
-   
-   
+   // inplace_erase
+
+
+
    //=========================================================================
    //
    // find
    //
    //=========================================================================
-   
-   /// \brief     
+
+   /// \brief
    /// check whether a substring occurs in a string at a given position
    /// \details
-   /// Searches the string for the first occurrence of the 
+   /// Searches the string for the first occurrence of the
    /// sequence specified by its arguments.
-   /// 
-   /// When pos is specified, the search only includes characters 
-   /// at or after position pos, ignoring any possible occurrences 
+   ///
+   /// When pos is specified, the search only includes characters
+   /// at or after position pos, ignoring any possible occurrences
    /// that include characters before pos.
    template< typename T >
    bool find_at( const T & s, size_t pos = 0 ) const {
       for( char c : iterate( s ) ){
-         if( ( pos >= current_length ) || ( content[ pos++ ] != c ) ){ 
-            return false;            
-         }            
-      }   
+         if( ( pos >= current_length ) || ( content[ pos++ ] != c ) ){
+            return false;
+         }
+      }
       return true;
    }
-   
-   /// \brief     
+
+   /// \brief
    /// find a substring in a string
    /// \details
-   /// Searches the string for the first occurrence of the 
+   /// Searches the string for the first occurrence of the
    /// sequence specified by its arguments.
-   /// 
-   /// When pos is specified, the search only includes characters 
-   /// at or after position pos, ignoring any possible occurrences 
+   ///
+   /// When pos is specified, the search only includes characters
+   /// at or after position pos, ignoring any possible occurrences
    /// that include characters before pos.
    ///
    /// When no match is found, nsize is returned.
@@ -435,41 +435,41 @@ public:
       while( pos < current_length ){
          if( find_at( s, pos ) ){
             return pos;
-         }     
-      }     
+         }
+      }
       return nsize;
-   }      
-   
-   /// \brief     
+   }
+
+   /// \brief
    /// find a substring in a string
    /// \details
-   /// Searches the string for the last occurrence of the 
+   /// Searches the string for the last occurrence of the
    /// sequence specified by its arguments.
-   /// 
-   /// When pos is specified, the search only includes characters 
-   /// at or after position pos, ignoring any possible occurrences 
+   ///
+   /// When pos is specified, the search only includes characters
+   /// at or after position pos, ignoring any possible occurrences
    /// that include characters before pos.
    ///
-   /// When no match is found, nsize is returned.   
+   /// When no match is found, nsize is returned.
    template< typename T >
    size_t rfind( const T & s, size_t pos = 0 ) const {
       size_t i = current_length;
       while( pos < i ){
          if( find_at( s, i ) ){
             return i;
-         }     
-      }     
+         }
+      }
       return nsize;
-   }   
-   
-   
+   }
+
+
    //=========================================================================
    //
    // operator[]
    //
    //=========================================================================
-   
-   /// \brief   
+
+   /// \brief
    /// return n'th character reference
    /// \details
    /// Return a reference to the n'th character if the index is valid,
@@ -478,7 +478,7 @@ public:
       return valid_index( n ) ? content[ n ] : dummy;
    }
 
-   /// \brief      
+   /// \brief
    /// return n'th character value
    /// \details
    /// Return the value of the n'th character if the index is valid,
@@ -486,192 +486,192 @@ public:
    char operator[]( int n ) const {
       return valid_index( n ) ? content[ n ] : '?';
    }
-   
-   
+
+
    //=========================================================================
    //
    // ranges
    //
-   //=========================================================================   
-   
+   //=========================================================================
+
    /*
    string_range range_start_length( size_t a, size_t b ){
-      return string_range( sanitize( a ), sanitize( a + b ) );   
+      return string_range( sanitize( a ), sanitize( a + b ) );
    }
-   
+
    string_range range_start_end( size_t a, size_t b ){
-      return string_range( sanitize( a ), sanitize( b ) );   
+      return string_range( sanitize( a ), sanitize( b ) );
    }
-   
+
    template< typename T >
    string_range range_find_length( const T & a, size_t b ){
-      return string_range( sanitize( a ), sanitize( a + b ) );   
+      return string_range( sanitize( a ), sanitize( a + b ) );
    }
-  
+
    template< typename T, typename Q >
    string_range range_find_find( const T & a, const Q & b ){
-      return string_range( sanitize( a ), sanitize( a + b ) );   
+      return string_range( sanitize( a ), sanitize( a + b ) );
    }
    */
-   
+
    //=========================================================================
    //
-   // compare 
+   // compare
    //
-   //=========================================================================        
-   
-   /// \brief   
+   //=========================================================================
+
+   /// \brief
    /// compare for equality
    template< typename T >
-   bool operator==( const T & rhs ) const {         
-      const char * p = content;       
-      for( const char c : iterate( rhs ) ){       
+   bool operator==( const T & rhs ) const {
+      const char * p = content;
+      for( const char c : iterate( rhs ) ){
           if( c != *p++ ){
               return false;
           }
       }
-      return *p == '\0';
-   }    
+      return true;
+   }
 
-   /// \brief   
+   /// \brief
    /// compare for inequality
    template< typename T >
-   bool operator!=( const T & rhs ) const {   
+   bool operator!=( const T & rhs ) const {
       return ! ( *this == rhs );
-   }   
-   
-   /// \brief   
-   /// compare for larger than 
+   }
+
+   /// \brief
+   /// compare for larger than
    template< typename T >
    bool operator>( const T & rhs ) const {
-      const char * p = content;       
+      const char * p = content;
       for( const char c : iterate( rhs ) ){
           if( *p == '\0' ){
-             return false;             
-          }   
+             return false;
+          }
           if( *p++ <= c ){
              return false;
           }
       }
       return true;
-   }    
+   }
 
-   /// \brief   
+   /// \brief
    /// compare for larger than or equal
    template< typename T >
    bool operator>=( const T & rhs ) const {
-      const char * p = content;       
+      const char * p = content;
       for( const char c : iterate( rhs ) ){
           if( *p == '\0' ){
-             return false;             
-          }   
+             return false;
+          }
           if( *p++ < c ){
              return false;
           }
       }
       return true;
-   }    
+   }
 
-   /// \brief   
-   /// compare for smaller than 
+   /// \brief
+   /// compare for smaller than
    template< typename T >
    bool operator<( const T & rhs ) const {
-      const char * p = content;       
+      const char * p = content;
       for( const char c : iterate( rhs ) ){
           if( *p == '\0' ){
-             return true;             
-          }   
+             return true;
+          }
           if( *p++ >= c ){
              return false;
           }
       }
       return false;
-   }    
+   }
 
-   /// \brief   
+   /// \brief
    /// compare for smaller than or equal
    template< typename T >
    bool operator<=( const T & rhs ) const {
-      const char * p = content;       
+      const char * p = content;
       for( const char c : iterate( rhs ) ){
           if( *p == '\0' ){
-             return true;             
-          }   
+             return true;
+          }
           if( *p++ > c ){
              return false;
           }
       }
       return false;
-   }    
+   }
 
 };
 
 //============================================================================
 //
 // static dummy
-//  
+//
 //============================================================================
 
-#ifdef HWLIB_ONCE 
-char string<0>::dummy; 
+#ifdef HWLIB_ONCE
+char string<0>::dummy;
 #endif
 
 //============================================================================
 //
 // reverse compare
-//  
+//
 //============================================================================
 
-/// \brief   
+/// \brief
 /// compare for equality
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator==( const T & lhs, const string< 0 > & rhs ){
    return rhs.operator==( lhs );
 }
 
-/// \brief   
+/// \brief
 /// compare for inequality
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator!=( const T & lhs, const string< 0 > & rhs ){
    return rhs.operator!=( lhs );
 }
 
-/// \brief   
+/// \brief
 /// compare for large than
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator>( const T & lhs, const string< 0 > & rhs ){
    return ! rhs.operator<=( lhs );
 }
 
-/// \brief   
+/// \brief
 /// compare for large than or equal
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator>=( const T & lhs, const string< 0 > & rhs ){
    return ! rhs.operator<( lhs );
 }
 
-/// \brief   
+/// \brief
 /// compare for smaller than
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator<( const T & lhs, const string< 0 > & rhs ){
    return ! rhs.operator>=( lhs );
 }
 
-/// \brief   
+/// \brief
 /// compare for smaller than or equal
-template< typename T >   
-typename std::enable_if < 
-   ! std::is_base_of< string< 0 >, T >::value, bool >::type    
+template< typename T >
+typename std::enable_if <
+   ! std::is_base_of< string< 0 >, T >::value, bool >::type
 operator<=( const T & lhs, const string< 0 > & rhs ){
    return ! rhs.operator>( lhs );
 }
@@ -681,14 +681,14 @@ operator<=( const T & lhs, const string< 0 > & rhs ){
 //
 // template< size_t N >
 // string< N >
-//  
+//
 //============================================================================
 
-/// \brief   
+/// \brief
 /// concrete fixed-maximum-length string
 /// \details
 /// This is the concrete string class template. Use it to declare
-/// a variable of a known (maximum) size. 
+/// a variable of a known (maximum) size.
 /// Use string< 0 > for references, parameters, ranges, etc.
 template< size_t maximum_length >
 class string: public string< 0 > {
@@ -696,28 +696,28 @@ private:
 
    // the store for the characters
    char content[ maximum_length ];
-   
+
 public:
 
-   /// \brief   
+   /// \brief
    /// create fixed-maximum-size string, initially empty
    string():
       string< 0 >( maximum_length, content, "" )
-   {}      
-   
-   /// \brief      
+   {}
+
+   /// \brief
    /// create fixed-maximum-size string, with an initial value
-   template< typename T > 
+   template< typename T >
    string( const T & x ):
       string< 0 >( maximum_length, content, x )
-   {}      
+   {}
 
    // avoid ambiguity
    string & operator=( const string & rhs ){
        string< 0 >::operator=( rhs );
        return *this;
    }
-   
+
 };
 
 }; // namespace hwlib


### PR DESCRIPTION
I was having issues with comparing strings and it turns out strings can only be equal if they are null terminated, my strings where not.

Non null terminated strings are equal to any other string

Stop this racism.