### PR TITLE
fixing compare by ending which had a faulty end checker

### DIFF
--- a/library/hwlib-string.hpp
+++ b/library/hwlib-string.hpp
@@ -525,14 +525,14 @@ public:
    /// \brief   
    /// compare for equality
    template< typename T >
-   bool operator==( const T & rhs ) const {         
+   bool operator==( const T & rhs ) const {
       const char * p = content;       
       for( const char c : iterate( rhs ) ){       
           if( c != *p++ ){
               return false;
           }
       }
-      return *p == *end();
+      return p == end();
    }    
 
    /// \brief   

--- a/library/hwlib-string.hpp
+++ b/library/hwlib-string.hpp
@@ -532,7 +532,7 @@ public:
               return false;
           }
       }
-      return *p == '\0';
+      return *p == *end();
    }    
 
    /// \brief   


### PR DESCRIPTION
The == of the `hwlib::string` would never find a `'\0'` in his own string so I changed it to check for the end pointer.