### PR TITLE
adding cmakelists for including hwlib as a cmakelibrary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8)
+
+project (hwlib)
+set(CMAKE_BUILD_TYPE Release)
+
+add_library(hwlib INTERFACE)
+target_include_directories(hwlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/library)
+target_sources(hwlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/library/hwlib.cpp)


### PR DESCRIPTION
This Cmake files makes it possible to add hwlib as a Cmake library. This could work as followed:

```
add_subdirectory(deps/hwlib)
target_link_libraries (project.elf hwlib)
```

This will then take care of all the necessary includes and build steps.