### PR TITLE
Changed #include "sam3.h" to #include "sam3xa.h"

### DIFF
--- a/library/targets/hwlib-arduino-due-system-sam3xa.inc
+++ b/library/targets/hwlib-arduino-due-system-sam3xa.inc
@@ -27,7 +27,7 @@
 /* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
 /* ---------------------------------------------------------------------------- */
 
-#include "sam3.h"
+#include "sam3xa.h"
 
 struct sam3xa {
 


### PR DESCRIPTION
Sam3.h is not provided with the *.atpack provided by http://packs.download.atmel.com/ instead it is something which can only be received via the headers provided/generated by Atmel Studio. (Not even [asf](https://github.com/avrxml/asf/tree/master/sam/utils/cmsis/sam3x/include) provides it) Which I personally consider a slightly-less-than official resource.

Sam3xa.h instead is provided by the atpack, while sam3.h is only an alias towards sam3xa.h. Sam.h could be an alternative but I imagine conflicts occurring with other sam based devices, so the most specialized header would imo be the best fit.