### PR TITLE
Fix drawing of images in windows

### DIFF
--- a/library/graphics/hwlib-graphics-window.hpp
+++ b/library/graphics/hwlib-graphics-window.hpp
@@ -110,7 +110,7 @@ public:
       xy pos, 
       const image & img
    ){                 
-      for( const auto p : all( size ) ){
+      for( const auto p : all( img.size ) ){
          write( pos + p, img[ p ] );
       }
    }


### PR DESCRIPTION
The write member function of the window class that draws image objects should iterate through the size of the image instead of iterating through the entire window size. This bug fix provides a significant performance boost when printing font characters.